### PR TITLE
Fix product limit on ma reviews page

### DIFF
--- a/products.js
+++ b/products.js
@@ -47,18 +47,6 @@ class ProductStateManager {
     } else {
       // Add new product to the beginning (most recent first)
       this.products.unshift(normalizedProduct);
-      
-      // Maintain maximum number of products to prevent reviews page from getting too full
-      const MAX_PRODUCTS = 20; // Limit to 20 products on reviews page
-      if (this.products.length > MAX_PRODUCTS) {
-        // Remove oldest products (from the end of array)
-        const removedProducts = this.products.splice(MAX_PRODUCTS);
-        // Remove from map as well
-        removedProducts.forEach(product => {
-          this.productMap.delete(product.id);
-        });
-        console.log(`Removed ${removedProducts.length} oldest products to maintain limit of ${MAX_PRODUCTS}`);
-      }
     }
     
     // Update in map for fast lookup
@@ -82,14 +70,14 @@ class ProductStateManager {
     return this.products.length;
   }
 
-  // Get maximum allowed products
-  getMaxProducts() {
+  // Get maximum allowed products (for reviews page only)
+  getMaxProductsForReviews() {
     return 20;
   }
 
-  // Check if at product limit
-  isAtProductLimit() {
-    return this.products.length >= this.getMaxProducts();
+  // Check if at product limit (for reviews page only)
+  isAtProductLimitForReviews() {
+    return this.products.length >= this.getMaxProductsForReviews();
   }
 
   // Update products from external source (Firebase, localStorage)
@@ -104,21 +92,15 @@ class ProductStateManager {
       return dateB - dateA;
     });
     
-    // Limit to maximum products to prevent reviews page overflow
-    const MAX_PRODUCTS = 20;
-    const productsToAdd = sortedProducts.slice(0, MAX_PRODUCTS);
-    
-    productsToAdd.forEach(product => {
-      // Add without triggering individual limit checks since we're already limiting here
+    // Add all products (no global limit)
+    sortedProducts.forEach(product => {
       const id = this.generateProductId(product);
       const normalizedProduct = this.normalizeProduct(product, id);
       this.products.push(normalizedProduct);
       this.productMap.set(id, normalizedProduct);
     });
     
-    if (sortedProducts.length > MAX_PRODUCTS) {
-      console.log(`Loaded ${productsToAdd.length} most recent products out of ${sortedProducts.length} total products`);
-    }
+    console.log(`Loaded ${sortedProducts.length} products`);
     
     this.notifyListeners();
   }
@@ -273,14 +255,14 @@ function getProductCount() {
   return productStateManager.getProductCount();
 }
 
-// Global function to check if at product limit
-function isAtProductLimit() {
-  return productStateManager.isAtProductLimit();
+// Global function to check if at product limit (for reviews page only)
+function isAtProductLimitForReviews() {
+  return productStateManager.isAtProductLimitForReviews();
 }
 
-// Global function to get max products allowed
-function getMaxProducts() {
-  return productStateManager.getMaxProducts();
+// Global function to get max products allowed (for reviews page only)
+function getMaxProductsForReviews() {
+  return productStateManager.getMaxProductsForReviews();
 }
 
 // Always expose products array for backward compatibility

--- a/reviews.html
+++ b/reviews.html
@@ -319,6 +319,19 @@
       if (category && category !== 'all') {
         productsToShow = getProductsByCategory(category);
       }
+      
+      // Apply 20-product limit specifically for reviews page to keep it fast and clean
+      const MAX_PRODUCTS_ON_REVIEWS = 20;
+      if (productsToShow && productsToShow.length > MAX_PRODUCTS_ON_REVIEWS) {
+        // Sort by creation date (newest first) and take only the most recent 20
+        productsToShow = [...productsToShow]
+          .sort((a, b) => {
+            const dateA = new Date(a.createdAt || 0);
+            const dateB = new Date(b.createdAt || 0);
+            return dateB - dateA;
+          })
+          .slice(0, MAX_PRODUCTS_ON_REVIEWS);
+      }
       if (!productsToShow || productsToShow.length === 0) {
         reviewsGrid.innerHTML = `<div class="no-reviews"><i class="fas fa-star" style="font-size: 3rem; color: #9ca3af; margin-bottom: 1rem;"></i><h3>No reviews found</h3><p>Check back later for more product reviews!</p></div>`;
         return;
@@ -409,13 +422,14 @@
           border-left: 4px solid #3b82f6;
         `;
         
-        const currentCount = getProductCount();
-        const maxCount = getMaxProducts();
+        const totalCount = getProductCount();
+        const maxCountOnReviews = 20;
+        const displayCount = Math.min(totalCount, maxCountOnReviews);
         
         infoDiv.innerHTML = `
           <i class="fas fa-info-circle" style="color: #3b82f6; margin-right: 0.5rem;"></i>
-          <strong>Smart Product Management:</strong> Showing ${currentCount} of maximum ${maxCount} products. 
-          When new products are added, oldest ones are automatically removed to keep the page fast and clean.
+          <strong>Smart Reviews Display:</strong> Showing ${displayCount} most recent products${totalCount > maxCountOnReviews ? ` out of ${totalCount} total` : ''}. 
+          Reviews page displays the latest ${maxCountOnReviews} products to keep loading fast and clean.
         `;
         
         const reviewsSection = document.querySelector('.latest-reviews .container');


### PR DESCRIPTION
Reverts global 20-product limit and automatic deletion, applying the limit only to the reviews page.

The previous implementation incorrectly applied a 20-product display limit and deletion logic globally in `products.js`, causing all product-related pages to show only 20 items and delete older ones. This PR ensures only the `reviews.html` page has this specific display behavior, while other product pages show all available products.

---
<a href="https://cursor.com/background-agent?bcId=bc-f92179d9-2b6b-4e68-a6a7-3292265c0c2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f92179d9-2b6b-4e68-a6a7-3292265c0c2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

