### PR TITLE
Ensure original products display after data clear

### DIFF
--- a/demo-cleanup.js
+++ b/demo-cleanup.js
@@ -6,59 +6,117 @@
   
   console.log('🔄 Starting demo product cleanup...');
   
-  // Function to identify demo products
+  // Check if this appears to be a fresh session (site data cleared)
+  function isFreshSession() {
+    const hasAnyProducts = localStorage.getItem('products');
+    const hasAnyCache = localStorage.getItem('allProducts');
+    const hasTimestamp = localStorage.getItem('products_updated');
+    
+    // If no cache exists at all, this is likely a fresh session
+    return !hasAnyProducts && !hasAnyCache && !hasTimestamp;
+  }
+  
+  // Function to identify demo products (more strict criteria)
   function isDemoProduct(product) {
     if (!product) return true;
     
-    // Check various demo indicators
+    // More specific demo indicators
     const demoIndicators = [
-      'Demo', 'Example', 'Sample', 'Test', 'Temporary'
+      'Demo Product', 'Example Product', 'Sample Product', 'Test Product'
     ];
     
     const demoIdPatterns = [
-      'prod_sample_', 'demo_', 'sample_', 'test_'
+      'prod_sample_', 'demo_', 'sample_', 'test_', 'temp_'
     ];
     
-    // Check name/title for demo indicators
+    // Check name/title for exact demo indicators (more strict)
     const name = (product.name || product.title || '').toLowerCase();
-    const hasDemoName = demoIndicators.some(indicator => 
+    const hasExactDemoName = demoIndicators.some(indicator => 
       name.includes(indicator.toLowerCase())
     );
     
     // Check ID for demo patterns
-    const id = (product.id || '').toString();
+    const id = (product.id || '').toString().toLowerCase();
     const hasDemoId = demoIdPatterns.some(pattern => 
       id.includes(pattern)
     );
     
-    // Check for placeholder links
-    const hasPlaceholderLink = !product.link || 
-                              product.link === '#' || 
+    // Check for obvious placeholder links (but be more lenient during loading)
+    const hasPlaceholderLink = product.link === '#' || 
                               product.link === '' ||
-                              product.link.includes('placeholder');
+                              (product.link && product.link.includes('placeholder'));
     
-    return hasDemoName || hasDemoId || hasPlaceholderLink;
+    // More strict: only remove if multiple indicators are present or very obvious demo
+    const isObviousDemo = hasExactDemoName || hasDemoId;
+    const isPossibleDemo = hasPlaceholderLink && (hasExactDemoName || hasDemoId);
+    
+    return isObviousDemo || isPossibleDemo;
   }
   
   // Clean up products from localStorage
   function cleanupLocalStorage() {
+    // If this is a fresh session, be more cautious
+    const freshSession = isFreshSession();
+    
+    if (freshSession) {
+      console.log('🔍 Fresh session detected - being cautious with demo cleanup');
+      // In fresh sessions, only remove very obvious demo products
+      // This prevents accidentally removing real products during initial Firebase loading
+      setTimeout(() => {
+        performCleanup(true); // cautious mode
+      }, 3000); // Wait 3 seconds for Firebase to start loading
+      return;
+    }
+    
+    performCleanup(false); // normal mode
+  }
+  
+  function performCleanup(cautiousMode = false) {
     try {
       // Clean up 'products' key
       const products = JSON.parse(localStorage.getItem('products') || '[]');
-      const filteredProducts = products.filter(product => !isDemoProduct(product));
+      let filteredProducts;
+      
+      if (cautiousMode) {
+        // In cautious mode, only remove very obvious demo products
+        filteredProducts = products.filter(product => {
+          const isDemoResult = isDemoProduct(product);
+          // Only remove if it's obviously demo AND has demo ID patterns
+          const id = (product.id || '').toString().toLowerCase();
+          const hasObviousDemoId = ['prod_sample_', 'demo_', 'sample_', 'test_'].some(pattern => 
+            id.includes(pattern)
+          );
+          return !(isDemoResult && hasObviousDemoId);
+        });
+      } else {
+        filteredProducts = products.filter(product => !isDemoProduct(product));
+      }
       
       if (filteredProducts.length !== products.length) {
         localStorage.setItem('products', JSON.stringify(filteredProducts));
-        console.log(`🗑️ Removed ${products.length - filteredProducts.length} demo products from 'products' cache`);
+        console.log(`🗑️ Removed ${products.length - filteredProducts.length} demo products from 'products' cache${cautiousMode ? ' (cautious mode)' : ''}`);
       }
       
       // Clean up 'allProducts' key
       const allProducts = JSON.parse(localStorage.getItem('allProducts') || '[]');
-      const filteredAllProducts = allProducts.filter(product => !isDemoProduct(product));
+      let filteredAllProducts;
+      
+      if (cautiousMode) {
+        filteredAllProducts = allProducts.filter(product => {
+          const isDemoResult = isDemoProduct(product);
+          const id = (product.id || '').toString().toLowerCase();
+          const hasObviousDemoId = ['prod_sample_', 'demo_', 'sample_', 'test_'].some(pattern => 
+            id.includes(pattern)
+          );
+          return !(isDemoResult && hasObviousDemoId);
+        });
+      } else {
+        filteredAllProducts = allProducts.filter(product => !isDemoProduct(product));
+      }
       
       if (filteredAllProducts.length !== allProducts.length) {
         localStorage.setItem('allProducts', JSON.stringify(filteredAllProducts));
-        console.log(`🗑️ Removed ${allProducts.length - filteredAllProducts.length} demo products from 'allProducts' cache`);
+        console.log(`🗑️ Removed ${allProducts.length - filteredAllProducts.length} demo products from 'allProducts' cache${cautiousMode ? ' (cautious mode)' : ''}`);
       }
       
       // Clean up any other product-related keys
@@ -73,10 +131,23 @@
         try {
           const data = JSON.parse(localStorage.getItem(key) || '[]');
           if (Array.isArray(data)) {
-            const filtered = data.filter(product => !isDemoProduct(product));
+            let filtered;
+            if (cautiousMode) {
+              filtered = data.filter(product => {
+                const isDemoResult = isDemoProduct(product);
+                const id = (product.id || '').toString().toLowerCase();
+                const hasObviousDemoId = ['prod_sample_', 'demo_', 'sample_', 'test_'].some(pattern => 
+                  id.includes(pattern)
+                );
+                return !(isDemoResult && hasObviousDemoId);
+              });
+            } else {
+              filtered = data.filter(product => !isDemoProduct(product));
+            }
+            
             if (filtered.length !== data.length) {
               localStorage.setItem(key, JSON.stringify(filtered));
-              console.log(`🗑️ Removed ${data.length - filtered.length} demo products from '${key}' cache`);
+              console.log(`🗑️ Removed ${data.length - filtered.length} demo products from '${key}' cache${cautiousMode ? ' (cautious mode)' : ''}`);
             }
           }
         } catch (e) {
@@ -90,23 +161,50 @@
   }
   
   // Clean up global product arrays
-  function cleanupGlobalProducts() {
+  function cleanupGlobalProducts(cautiousMode = false) {
     try {
       // Clean up window.products
       if (window.products && Array.isArray(window.products)) {
         const originalLength = window.products.length;
-        window.products = window.products.filter(product => !isDemoProduct(product));
+        
+        if (cautiousMode) {
+          // In cautious mode, only remove very obvious demo products
+          window.products = window.products.filter(product => {
+            const isDemoResult = isDemoProduct(product);
+            const id = (product.id || '').toString().toLowerCase();
+            const hasObviousDemoId = ['prod_sample_', 'demo_', 'sample_', 'test_'].some(pattern => 
+              id.includes(pattern)
+            );
+            return !(isDemoResult && hasObviousDemoId);
+          });
+        } else {
+          window.products = window.products.filter(product => !isDemoProduct(product));
+        }
+        
         if (window.products.length !== originalLength) {
-          console.log(`🗑️ Removed ${originalLength - window.products.length} demo products from window.products`);
+          console.log(`🗑️ Removed ${originalLength - window.products.length} demo products from window.products${cautiousMode ? ' (cautious mode)' : ''}`);
         }
       }
       
       // Clean up window.allProductsIncludingUserSubmitted
       if (window.allProductsIncludingUserSubmitted && Array.isArray(window.allProductsIncludingUserSubmitted)) {
         const originalLength = window.allProductsIncludingUserSubmitted.length;
-        window.allProductsIncludingUserSubmitted = window.allProductsIncludingUserSubmitted.filter(product => !isDemoProduct(product));
+        
+        if (cautiousMode) {
+          window.allProductsIncludingUserSubmitted = window.allProductsIncludingUserSubmitted.filter(product => {
+            const isDemoResult = isDemoProduct(product);
+            const id = (product.id || '').toString().toLowerCase();
+            const hasObviousDemoId = ['prod_sample_', 'demo_', 'sample_', 'test_'].some(pattern => 
+              id.includes(pattern)
+            );
+            return !(isDemoResult && hasObviousDemoId);
+          });
+        } else {
+          window.allProductsIncludingUserSubmitted = window.allProductsIncludingUserSubmitted.filter(product => !isDemoProduct(product));
+        }
+        
         if (window.allProductsIncludingUserSubmitted.length !== originalLength) {
-          console.log(`🗑️ Removed ${originalLength - window.allProductsIncludingUserSubmitted.length} demo products from window.allProductsIncludingUserSubmitted`);
+          console.log(`🗑️ Removed ${originalLength - window.allProductsIncludingUserSubmitted.length} demo products from window.allProductsIncludingUserSubmitted${cautiousMode ? ' (cautious mode)' : ''}`);
         }
       }
       
@@ -138,25 +236,39 @@
     return originalSetItem.call(this, key, value);
   };
   
-  // Run cleanup immediately
-  cleanupLocalStorage();
-  cleanupGlobalProducts();
+  // Determine if we should use cautious mode
+  const isFresh = isFreshSession();
+  
+  // Run cleanup immediately (cautious if fresh session)
+  if (isFresh) {
+    console.log('🔍 Fresh session detected - starting cautious demo cleanup');
+    // For fresh sessions, wait a bit before cleaning to let Firebase start loading
+    setTimeout(() => {
+      cleanupLocalStorage();
+      cleanupGlobalProducts(true); // cautious mode
+    }, 2000);
+  } else {
+    cleanupLocalStorage();
+    cleanupGlobalProducts(false); // normal mode
+  }
   
   // Run cleanup when DOM is ready
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
-      cleanupGlobalProducts();
+      cleanupGlobalProducts(isFresh);
     });
   } else {
-    cleanupGlobalProducts();
+    cleanupGlobalProducts(isFresh);
   }
   
   // Run cleanup periodically to catch any new demo products
   setInterval(() => {
+    // After initial load, use normal cleanup mode
+    const currentlyFresh = isFreshSession();
     cleanupLocalStorage();
-    cleanupGlobalProducts();
+    cleanupGlobalProducts(currentlyFresh);
   }, 30000); // Check every 30 seconds
   
-  console.log('✅ Demo product cleanup completed and monitoring active');
+  console.log(`✅ Demo product cleanup completed and monitoring active${isFresh ? ' (cautious mode for fresh session)' : ''}`);
   
 })();

--- a/test-site-data-clear-fix.html
+++ b/test-site-data-clear-fix.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Site Data Clear Fix Test - SmartDeals Pro</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 20px;
+      background-color: #f5f5f5;
+    }
+    .container {
+      background: white;
+      padding: 20px;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      margin-bottom: 20px;
+    }
+    .status {
+      padding: 10px;
+      margin: 10px 0;
+      border-radius: 4px;
+    }
+    .success { background-color: #d4edda; color: #155724; }
+    .warning { background-color: #fff3cd; color: #856404; }
+    .error { background-color: #f8d7da; color: #721c24; }
+    .info { background-color: #d1ecf1; color: #0c5460; }
+    button {
+      background: #007bff;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 4px;
+      cursor: pointer;
+      margin: 5px;
+    }
+    button:hover { background: #0056b3; }
+    button.danger { background: #dc3545; }
+    button.danger:hover { background: #c82333; }
+    .log {
+      background: #f8f9fa;
+      border: 1px solid #dee2e6;
+      padding: 10px;
+      border-radius: 4px;
+      max-height: 400px;
+      overflow-y: auto;
+      font-family: monospace;
+      font-size: 12px;
+    }
+    .product-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 15px;
+      margin-top: 20px;
+    }
+    .product-card {
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 15px;
+      background: white;
+    }
+    .product-demo {
+      border-color: #f0ad4e;
+      background: #fdf5e6;
+    }
+    .product-real {
+      border-color: #5cb85c;
+      background: #f0f8f0;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Site Data Clear Fix Test</h1>
+    <p>This page tests whether original products show correctly after clearing site data, without demo products interfering.</p>
+    
+    <div id="status" class="status info">
+      Initializing test...
+    </div>
+    
+    <div>
+      <button onclick="testFreshSession()">Test Fresh Session (Simulate Site Data Clear)</button>
+      <button onclick="addMixedProducts()">Add Mixed Demo/Real Products</button>
+      <button onclick="checkCurrentProducts()">Check Current Products</button>
+      <button onclick="clearAllData()" class="danger">Clear All Site Data</button>
+      <button onclick="simulateFirebaseLoad()">Simulate Firebase Load</button>
+    </div>
+    
+    <h3>Session Status:</h3>
+    <div id="sessionStatus" class="info status">Checking session type...</div>
+    
+    <h3>Current Products:</h3>
+    <div id="productDisplay" class="product-grid"></div>
+    
+    <h3>Test Log:</h3>
+    <div id="log" class="log"></div>
+  </div>
+
+  <!-- Load Firebase and demo cleanup scripts -->
+  <script src="firebase-config.js"></script>
+  <script src="demo-cleanup.js"></script>
+  
+  <script>
+    function log(message, type = 'info') {
+      const logDiv = document.getElementById('log');
+      const timestamp = new Date().toLocaleTimeString();
+      logDiv.innerHTML += `[${timestamp}] ${message}\n`;
+      logDiv.scrollTop = logDiv.scrollHeight;
+      console.log(message);
+    }
+
+    function updateStatus(message, type = 'info') {
+      const statusDiv = document.getElementById('status');
+      statusDiv.textContent = message;
+      statusDiv.className = `status ${type}`;
+    }
+
+    function checkSessionType() {
+      const hasAnyProducts = localStorage.getItem('products');
+      const hasAnyCache = localStorage.getItem('allProducts');
+      const hasTimestamp = localStorage.getItem('products_updated');
+      
+      const isFresh = !hasAnyProducts && !hasAnyCache && !hasTimestamp;
+      
+      const sessionDiv = document.getElementById('sessionStatus');
+      if (isFresh) {
+        sessionDiv.textContent = '🆕 Fresh Session Detected (Site data appears to be cleared)';
+        sessionDiv.className = 'warning status';
+        log('Fresh session detected - demo cleanup will be cautious');
+      } else {
+        sessionDiv.textContent = '📱 Normal Session (Cache exists)';
+        sessionDiv.className = 'success status';
+        log('Normal session detected - standard demo cleanup');
+      }
+      
+      return isFresh;
+    }
+
+    function testFreshSession() {
+      log('Simulating fresh session by clearing all data...');
+      clearAllData();
+      
+      setTimeout(() => {
+        log('Adding mixed products to test cleanup behavior...');
+        addMixedProducts();
+        
+        setTimeout(() => {
+          log('Checking cleanup results...');
+          checkCurrentProducts();
+        }, 4000); // Wait for cleanup to run
+      }, 1000);
+    }
+
+    function addMixedProducts() {
+      log('Adding mixed demo and real products...');
+      
+      const mixedProducts = [
+        // Obvious demo products (should be removed)
+        {
+          id: 'prod_sample_1',
+          name: 'Demo Product 1',
+          title: 'Demo Product 1',
+          price: '29.99',
+          link: '#',
+          type: 'demo'
+        },
+        {
+          id: 'demo_2',
+          name: 'Example Product',
+          title: 'Example Product',
+          price: '39.99',
+          link: '#',
+          type: 'demo'
+        },
+        // Real products (should be kept)
+        {
+          id: 'real_product_1',
+          name: 'Wireless Headphones',
+          title: 'Premium Wireless Headphones',
+          price: '99.99',
+          link: 'https://amzn.to/real-headphones',
+          type: 'real'
+        },
+        {
+          id: 'real_product_2',
+          name: 'Smart Watch',
+          title: 'Fitness Smart Watch',
+          price: '199.99',
+          link: 'https://amzn.to/real-smartwatch',
+          type: 'real'
+        },
+        // Edge case: Real product that might look like demo
+        {
+          id: 'real_product_3',
+          name: 'Product Tester Kit',
+          title: 'Product Testing Kit for Developers',
+          price: '49.99',
+          link: 'https://amzn.to/product-testing-kit',
+          type: 'real'
+        }
+      ];
+      
+      localStorage.setItem('products', JSON.stringify(mixedProducts));
+      localStorage.setItem('allProducts', JSON.stringify(mixedProducts));
+      
+      log(`Added ${mixedProducts.length} mixed products to localStorage`);
+      updateStatus(`Added ${mixedProducts.length} mixed products`, 'info');
+      displayProducts(mixedProducts);
+    }
+
+    function checkCurrentProducts() {
+      const products = JSON.parse(localStorage.getItem('products') || '[]');
+      const allProducts = JSON.parse(localStorage.getItem('allProducts') || '[]');
+      
+      log(`Current products in localStorage:`);
+      log(`- 'products': ${products.length} items`);
+      log(`- 'allProducts': ${allProducts.length} items`);
+      
+      let demoCount = 0;
+      let realCount = 0;
+      
+      products.forEach((product, index) => {
+        const isDemo = product.id?.includes('demo_') || 
+                      product.id?.includes('prod_sample_') || 
+                      product.name?.includes('Demo') || 
+                      product.name?.includes('Example');
+        
+        if (isDemo) {
+          demoCount++;
+          log(`  ${index + 1}. [DEMO] ${product.name} (ID: ${product.id})`);
+        } else {
+          realCount++;
+          log(`  ${index + 1}. [REAL] ${product.name} (ID: ${product.id})`);
+        }
+      });
+      
+      if (demoCount === 0 && realCount > 0) {
+        updateStatus(`✅ SUCCESS: ${realCount} real products, ${demoCount} demo products`, 'success');
+        log('✅ CLEANUP SUCCESS: All demo products removed, real products preserved');
+      } else if (demoCount > 0) {
+        updateStatus(`⚠️ WARNING: ${realCount} real products, ${demoCount} demo products remain`, 'warning');
+        log(`⚠️ CLEANUP PARTIAL: ${demoCount} demo products still remain`);
+      } else {
+        updateStatus('📭 No products found', 'info');
+        log('📭 No products in storage');
+      }
+      
+      displayProducts(products);
+      checkSessionType();
+    }
+
+    function displayProducts(products) {
+      const displayDiv = document.getElementById('productDisplay');
+      displayDiv.innerHTML = '';
+      
+      if (products.length === 0) {
+        displayDiv.innerHTML = '<p>No products to display</p>';
+        return;
+      }
+      
+      products.forEach(product => {
+        const isDemo = product.id?.includes('demo_') || 
+                      product.id?.includes('prod_sample_') || 
+                      product.name?.includes('Demo') || 
+                      product.name?.includes('Example');
+        
+        const card = document.createElement('div');
+        card.className = `product-card ${isDemo ? 'product-demo' : 'product-real'}`;
+        card.innerHTML = `
+          <div style="font-weight: bold; color: ${isDemo ? '#f0ad4e' : '#5cb85c'}">
+            ${isDemo ? '🚨 DEMO' : '✅ REAL'}
+          </div>
+          <h4>${product.name}</h4>
+          <p><strong>ID:</strong> ${product.id}</p>
+          <p><strong>Price:</strong> $${product.price}</p>
+          <p><strong>Link:</strong> ${product.link}</p>
+        `;
+        displayDiv.appendChild(card);
+      });
+    }
+
+    function clearAllData() {
+      log('Clearing all site data...');
+      localStorage.clear();
+      sessionStorage.clear();
+      log('All data cleared - simulating fresh browser session');
+      updateStatus('Site data cleared - fresh session simulated', 'warning');
+      checkSessionType();
+      displayProducts([]);
+    }
+
+    function simulateFirebaseLoad() {
+      log('Simulating Firebase loading real products...');
+      
+      const realFirebaseProducts = [
+        {
+          id: 'firebase_1',
+          name: 'Gaming Laptop',
+          title: 'High Performance Gaming Laptop',
+          price: '1299.99',
+          link: 'https://amzn.to/gaming-laptop',
+          category: 'electronics',
+          type: 'real'
+        },
+        {
+          id: 'firebase_2',
+          name: 'Bluetooth Speaker',
+          title: 'Portable Bluetooth Speaker',
+          price: '79.99',
+          link: 'https://amzn.to/bluetooth-speaker',
+          category: 'electronics',
+          type: 'real'
+        }
+      ];
+      
+      setTimeout(() => {
+        localStorage.setItem('products', JSON.stringify(realFirebaseProducts));
+        localStorage.setItem('products_updated', Date.now().toString());
+        log('Firebase products loaded successfully');
+        checkCurrentProducts();
+      }, 2000);
+    }
+
+    // Initialize test
+    document.addEventListener('DOMContentLoaded', function() {
+      log('Site Data Clear Fix Test loaded');
+      checkSessionType();
+      checkCurrentProducts();
+      
+      // Monitor localStorage changes
+      window.addEventListener('storage', function(e) {
+        if (e.key === 'products' || e.key === 'allProducts') {
+          log(`Storage changed: ${e.key}`);
+          checkCurrentProducts();
+        }
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Improve product loading after site data clear by making demo cleanup less aggressive and adjusting Firebase timeouts.

Previously, clearing site data led to a race condition where the `demo-cleanup.js` script would aggressively remove products before Firebase could fully load real products, sometimes resulting in an empty state or incorrect demo products being shown. This PR introduces a 'cautious mode' for demo cleanup in fresh sessions and extends Firebase loading timeouts to ensure real products are prioritized and loaded correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-da88bf24-05cd-4bba-bb8e-55ea14e97c53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da88bf24-05cd-4bba-bb8e-55ea14e97c53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

