### PR TITLE
Add home and marketplace to sidebar

### DIFF
--- a/affiliate-dashboard.html
+++ b/affiliate-dashboard.html
@@ -521,6 +521,10 @@
             </div>
 
             <nav class="sidebar-nav">
+                <a href="index.html" class="nav-item">
+                    <i class="fas fa-home"></i>
+                    Home
+                </a>
                 <a href="#" class="nav-item active" onclick="showSection('overview')">
                     <i class="fas fa-tachometer-alt"></i>
                     Dashboard
@@ -540,6 +544,10 @@
                 <a href="#" class="nav-item" onclick="showSection('profile')">
                     <i class="fas fa-user"></i>
                     Profile
+                </a>
+                <a href="marketplace.html" class="nav-item">
+                    <i class="fas fa-store"></i>
+                    Marketplace
                 </a>
             </nav>
 


### PR DESCRIPTION
Add Home and Marketplace links to the dashboard sidebar menu for improved navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-b86b331e-7896-41c9-9d5a-9c17c74aec56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b86b331e-7896-41c9-9d5a-9c17c74aec56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

